### PR TITLE
my pull request

### DIFF
--- a/plugin_upload.py
+++ b/plugin_upload.py
@@ -18,9 +18,9 @@ def main(options, args):
     address = "%s://%s:%s@%s:%s%s" % (PROTOCOL, options.username, options.password,
             options.server, options.port, ENDPOINT)
     print "Connecting to: %s" % hidepassword(address)
-    
+
     server = xmlrpclib.ServerProxy(address, verbose=VERBOSE)
-    
+
     try:
         plugin_id, version_id = server.plugin.upload(xmlrpclib.Binary(open(args[0]).read()))
         print "Plugin ID: %s" % plugin_id

--- a/spatialjoin.py
+++ b/spatialjoin.py
@@ -42,7 +42,8 @@ class trace:
 
     def ce(self,string):
         if self.trace:
-            print string
+            s = repr(string).decode('utf8')
+            print(s)
 
 class spatialJoin:
 

--- a/spatialjoin.py
+++ b/spatialjoin.py
@@ -39,7 +39,7 @@ class trace:
 
     def __init__(self):
         self.trace = True
-        
+
     def ce(self,string):
         if self.trace:
             print string

--- a/spatialjoin.py
+++ b/spatialjoin.py
@@ -38,7 +38,7 @@ class trace:
     """
 
     def __init__(self):
-        self.trace = True
+        self.trace = False
 
     def ce(self,string):
         if self.trace:

--- a/spatialjoin.py
+++ b/spatialjoin.py
@@ -165,8 +165,8 @@ class spatialJoin:
 
     def applyJoin(self):
         self.dlg.show()
-        selectedFields = self.getSelFieldList()
-        if selectedFields and self.dlg.targetLayerCombo.currentText()[:6] != 'Select' and self.dlg.joinLayerCombo.currentText()[:6] != 'Select' and self.dlg.spatialTypeCombo.currentText()[:6] != 'Select':
+        selectedFields = self.getSelFieldList() or []
+        if self.dlg.targetLayerCombo.currentText()[:6] != 'Select' and self.dlg.joinLayerCombo.currentText()[:6] != 'Select' and self.dlg.spatialTypeCombo.currentText()[:6] != 'Select':
             targetLayer = self.layerSet[self.dlg.targetLayerCombo.currentText()]
             joinLayer = self.layerSet[self.dlg.joinLayerCombo.currentText()]
             joinLayerFields = [field.name() for field in joinLayer.pendingFields()]

--- a/spatialjoin.py
+++ b/spatialjoin.py
@@ -205,7 +205,7 @@ class spatialJoin:
                 targetLayer.dataProvider().addAttributes([QgsField(joinField, QVariant.Int)])
                 #targetLayer.updateFields()
                 F = [field.name() for field in targetLayer.dataProvider().fields()]
-                self.tra.ce( F)
+                self.tra.ce(F)
                 #Compile spatial expression to get feature rifs
                 expObj = QgsExpression(exp)
                 expObj.prepare(targetLayer.pendingFields())
@@ -215,15 +215,12 @@ class spatialJoin:
                 #init progress bar
                 self.dlg.progressBar.setMinimum(0)
                 self.dlg.progressBar.setMaximum(targetLayer.featureCount())
-                count = 0
                 #cicle into feature to build mod vector
-                for feature in targetLayer.getFeatures():
+                for count, feature in enumerate(targetLayer.getFeatures()):
                     self.dlg.progressBar.setValue(count)
                     value = expObj.evaluate(feature)
-                    if value:
-                        changes[feature.id()] = {idx:value}
-                    count +=1
-                self.tra.ce( changes)
+                    changes[feature.id()] = {idx:value}
+                self.tra.ce(changes)
                 #apply mod vector
                 targetLayer.dataProvider().changeAttributeValues(changes)
             targetLayer.updateFields()


### PR DESCRIPTION
fixed issue #1
tracing disabled by default
I prefer using QGIS's Layer Joins (http://www.qgisforum.org/qgis-tutorial/layer-properties/joins) so normally I only need to get the matching IDs in the ref column. I do not like to get forced to select fields from the target layer.
